### PR TITLE
fix: correct '3 or 3' to '2 or 3' in Level 2 Intermediate description

### DIFF
--- a/README.md
+++ b/README.md
@@ -65,7 +65,7 @@ Beginner means someone who has just gone through an introductory Golang course. 
 
 ### Level 2 Intermediate
 
-Intermediate means someone who has just learned Golang, but already has a relatively strong programming background from before. He should be able to solve problems which may involve 3 or 3 Golang classes or functions. The answers cannot be directly be found in the textbooks.
+Intermediate means someone who has just learned Golang, but already has a relatively strong programming background from before. He should be able to solve problems which may involve 2 or 3 Golang classes or functions. The answers cannot be directly be found in the textbooks.
 
 ### Level 3 Advanced
 


### PR DESCRIPTION
Fixes issue #2 — corrects '3 or 3 Golang classes' to '2 or 3 Golang classes' in the Level 2 Intermediate description (readme typo/counting error).